### PR TITLE
hive-metastore: 환경변수 기반 설정 렌더링 + CI 워크플로

### DIFF
--- a/.github/workflows/hive-metastore.yml
+++ b/.github/workflows/hive-metastore.yml
@@ -1,0 +1,45 @@
+name: hive-metastore
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/hive-metastore.yml'
+      - 'containers/hive-metastore/**'
+
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'containers/hive-metastore/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: shepherd9664/hive-metastore
+          tags: |
+            type=raw,value=3.1.3-{{date 'YYYY.MM.DD-HHmm' tz='Asia/Seoul'}}
+            type=raw,value=latest
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build
+        uses: docker/build-push-action@v4
+        with:
+          context: ./containers/hive-metastore
+          file: containers/hive-metastore/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/containers/hive-metastore/start.sh
+++ b/containers/hive-metastore/start.sh
@@ -1,5 +1,30 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-#${METASTORE_HOME}/bin/start-metastore
-#/usr/sbin/sshd -D -e
-exec $@
+# 환경변수 기반 설정 렌더링.
+# HMS_RENDER_CONF="src:dst[,src:dst...]" 를 지정하면, 각 템플릿(src) 파일의 ${VAR}
+# placeholder 를 환경변수 값으로 치환해 dst 로 출력한다. DB 비밀번호 / S3 키 등
+# credential 을 설정 파일 평문 대신 env(예: k8s Secret)로 주입하기 위함이다.
+# 미지정 시 아무 동작도 하지 않으므로 기존 사용 방식과 호환된다.
+if [[ -n "${HMS_RENDER_CONF:-}" ]]; then
+  IFS=',' read -ra _entries <<< "${HMS_RENDER_CONF}"
+  for _entry in "${_entries[@]}"; do
+    _src="${_entry%%:*}"
+    _dst="${_entry#*:}"
+    if [[ -z "${_src}" || "${_src}" == "${_entry}" ]]; then
+      echo "[start.sh] invalid HMS_RENDER_CONF entry: '${_entry}' (expected src:dst)" >&2
+      exit 1
+    fi
+    if [[ ! -f "${_src}" ]]; then
+      echo "[start.sh] template not found: ${_src}" >&2
+      exit 1
+    fi
+    echo "[start.sh] rendering ${_src} -> ${_dst}"
+    # 정의된 환경변수만 치환하고, 미정의 placeholder 는 원형을 유지한다.
+    # 치환값을 정규식 replacement 가 아닌 $ENV 조회로 처리하므로 비밀번호의
+    # 특수문자(/, &, $ 등)도 안전하다.
+    perl -pe 's/\$\{(\w+)\}/exists $ENV{$1} ? $ENV{$1} : $&/ge' "${_src}" > "${_dst}"
+  done
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- `start.sh` 에 환경변수 기반 설정 렌더링 추가 — `HMS_RENDER_CONF="src:dst[,src:dst...]"` 지정 시 템플릿의 `${VAR}` placeholder 를 환경변수로 치환해 렌더링 후 exec
- 목적: DB 비밀번호 / S3 키 등 credential 을 설정 파일 평문 대신 env(k8s Secret)로 주입. ConfigMap 에 credential 미포함
- 미지정 시 기존 `exec $@` 동작과 동일 (하위호환)
- `hive-metastore` 는 CI 워크플로가 없어 수동 빌드되던 것을 `awscli.yml` 패턴으로 `.github/workflows/hive-metastore.yml` 추가

## 동작
- `perl` 치환 — 정의된 env 만 치환, 미정의 placeholder 는 원형 유지. 비밀번호 특수문자(`/ & $ { }`) 안전
- `perl` 은 base 이미지(`hadoop-base`)에 이미 포함 → Dockerfile 변경 없음

## 검증
- [x] `bash -n start.sh` 통과
- [x] perl 치환 로컬 테스트 — 특수문자 비밀번호 정상 치환, 미정의 변수 원형 유지
- [ ] merge 후 CI 빌드 → `shepherd9664/hive-metastore:3.1.3-<날짜>` 푸시 확인

## 후속
- 빌드된 이미지를 k8s-manifests `de-datalake-dev` 에 적용 (template ConfigMap + `HMS_RENDER_CONF` env), 검증 후 prod 에도 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)