### PR TITLE
hive-metastore: 이미지 태그에 hadoop 버전 포함

### DIFF
--- a/.github/workflows/hive-metastore.yml
+++ b/.github/workflows/hive-metastore.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           images: shepherd9664/hive-metastore
           tags: |
-            type=raw,value=3.1.3-{{date 'YYYY.MM.DD-HHmm' tz='Asia/Seoul'}}
+            type=raw,value=3.1.3-hadoop3.3.4-{{date 'YYYY.MM.DD-HHmm' tz='Asia/Seoul'}}
             type=raw,value=latest
       - name: Login to DockerHub
         uses: docker/login-action@v2


### PR DESCRIPTION
## Summary
- hive-metastore 이미지 태그를 `3.1.3-<날짜>` → `3.1.3-hadoop3.3.4-<날짜>` 로 변경
- Hive Metastore(3.1.3)와 Hadoop(3.3.4 — base 이미지·hadoop-aws jar) 버전을 함께 드러냄
- awscli 의 `2.15.34-postgres14-<날짜>` 패턴과 일관

## 비고
- 변경 파일이 `.github/workflows/hive-metastore.yml` 이라 PR 에선 빌드 트리거 안 됨(`pull_request` path 필터는 `containers/hive-metastore/**`). merge 시 `push` 트리거로 재빌드됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)