### PR TITLE
hive-metastore: add hcatalog listener jar + CI workflow

### DIFF
--- a/.github/workflows/hive-metastore.yml
+++ b/.github/workflows/hive-metastore.yml
@@ -1,0 +1,61 @@
+name: hive-metastore
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/hive-metastore.yml'
+      - 'containers/hive-metastore/**'
+
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  files-changed:
+    name: detect file change
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      hive_metastore: ${{ steps.changes.outputs.hive_metastore }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@main
+      - name: Check for backend file changes
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yaml
+
+  build:
+    if: needs.files-changed.outputs.hive_metastore == 'true'
+    needs: files-changed
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: shepherd9664/hive-metastore
+          tags: |
+            type=raw,value=3.1.3-hadoop3.3.4-{{date 'YYYY.MM.DD-HHmm' tz='Asia/Seoul'}}
+            3.1.3-hadoop3.3.4-latest
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build
+        uses: docker/build-push-action@v4
+        with:
+          context: ./containers/hive-metastore
+          file: containers/hive-metastore/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/containers/hive-metastore/Dockerfile
+++ b/containers/hive-metastore/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update \
 ARG postgresql_jar_version=42.5.1
 ARG hadoop_aws_version=3.3.4
 ARG aws_java_sdk_bundle_version=1.12.396
+# DbNotificationListener(메타데이터 변경 이벤트 → NOTIFICATION_LOG 적재) 제공 jar.
+# standalone-metastore 배포본에는 미포함이라 별도 추가. DataHub 등 메타데이터 감사/카탈로그용.
+ARG hive_hcatalog_version=3.1.3
 ENV HIVE_VERSION=3.1.3
 ENV HIVE_METASTORE_URL=https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore/${HIVE_VERSION}/hive-standalone-metastore-${HIVE_VERSION}-bin.tar.gz
 ENV METASTORE_HOME=/opt/hive-metastore
@@ -23,7 +26,9 @@ RUN mkdir -p /opt \
     && curl -fSL https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/${hadoop_aws_version}/hadoop-aws-${hadoop_aws_version}.jar \
       -o ${METASTORE_HOME}/lib/hadoop-aws-${hadoop_aws_version}.jar \
     && curl -fSL https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/${aws_java_sdk_bundle_version}/aws-java-sdk-bundle-${aws_java_sdk_bundle_version}.jar \
-      -o /${METASTORE_HOME}/lib/aws-java-sdk-bundle-${aws_java_sdk_bundle_version}.jar
+      -o /${METASTORE_HOME}/lib/aws-java-sdk-bundle-${aws_java_sdk_bundle_version}.jar \
+    && curl -fSL https://repo1.maven.org/maven2/org/apache/hive/hcatalog/hive-hcatalog-server-extensions/${hive_hcatalog_version}/hive-hcatalog-server-extensions-${hive_hcatalog_version}.jar \
+      -o ${METASTORE_HOME}/lib/hive-hcatalog-server-extensions-${hive_hcatalog_version}.jar
 
 COPY conf ${METASTORE_HOME}/conf
 COPY start.sh /opt/start.sh


### PR DESCRIPTION
## Summary
- `containers/hive-metastore/Dockerfile`: `hive-hcatalog-server-extensions-3.1.3.jar` 추가 → `DbNotificationListener` 제공 (standalone-metastore 기본 미포함)
- `.github/workflows/hive-metastore.yml` 신규: hive-metastore 이미지 빌드/푸시 CI (기존 airflow/awscli 워크플로 패턴 동일)

## 배경
HMS 메타데이터 변경 이벤트를 NOTIFICATION_LOG 에 적재(DataHub 등 메타데이터 감사/카탈로그 연동)하려면 `metastore.transactional.event.listeners=DbNotificationListener` 가 필요한데, 이 클래스가 들어있는 hcatalog-server-extensions jar 가 standalone-metastore 배포본에 없어 이미지에 추가.

## 주요 변경점
- [ ] `containers/hive-metastore/Dockerfile` - hcatalog server-extensions jar curl 추가 (DbNotificationListener.class 포함 확인 완료)
- [ ] `.github/workflows/hive-metastore.yml` - 태그 `3.1.3-hadoop3.3.4-{date}` + `...-latest`, DOCKERHUB_USERNAME/TOKEN secret 사용

## Test plan
- [ ] PR CI(build, push=false)에서 이미지 빌드 성공
- [ ] merge 후 main CI 에서 Docker Hub 푸시 성공
- [ ] 푸시된 태그로 dev HMS 배포 → pod 정상 기동(ClassNotFound 없음) + NOTIFICATION_LOG 적재 확인