### PR TITLE
hive-metastore: add hcatalog jar for DbNotificationListener

### DIFF
--- a/containers/hive-metastore/Dockerfile
+++ b/containers/hive-metastore/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update \
 ARG postgresql_jar_version=42.5.1
 ARG hadoop_aws_version=3.3.4
 ARG aws_java_sdk_bundle_version=1.12.396
+# DbNotificationListener(메타데이터 변경 이벤트 → NOTIFICATION_LOG 적재) 제공 jar.
+# standalone-metastore 배포본에는 미포함이라 별도 추가. DataHub 등 메타데이터 감사/카탈로그용.
+ARG hive_hcatalog_version=3.1.3
 ENV HIVE_VERSION=3.1.3
 ENV HIVE_METASTORE_URL=https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore/${HIVE_VERSION}/hive-standalone-metastore-${HIVE_VERSION}-bin.tar.gz
 ENV METASTORE_HOME=/opt/hive-metastore
@@ -23,7 +26,9 @@ RUN mkdir -p /opt \
     && curl -fSL https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/${hadoop_aws_version}/hadoop-aws-${hadoop_aws_version}.jar \
       -o ${METASTORE_HOME}/lib/hadoop-aws-${hadoop_aws_version}.jar \
     && curl -fSL https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/${aws_java_sdk_bundle_version}/aws-java-sdk-bundle-${aws_java_sdk_bundle_version}.jar \
-      -o /${METASTORE_HOME}/lib/aws-java-sdk-bundle-${aws_java_sdk_bundle_version}.jar
+      -o /${METASTORE_HOME}/lib/aws-java-sdk-bundle-${aws_java_sdk_bundle_version}.jar \
+    && curl -fSL https://repo1.maven.org/maven2/org/apache/hive/hcatalog/hive-hcatalog-server-extensions/${hive_hcatalog_version}/hive-hcatalog-server-extensions-${hive_hcatalog_version}.jar \
+      -o ${METASTORE_HOME}/lib/hive-hcatalog-server-extensions-${hive_hcatalog_version}.jar
 
 COPY conf ${METASTORE_HOME}/conf
 COPY start.sh /opt/start.sh


### PR DESCRIPTION
## Summary
- `containers/hive-metastore/Dockerfile`: `hive-hcatalog-server-extensions-3.1.3.jar` 추가 → `DbNotificationListener` 클래스 제공 (standalone-metastore 기본 미포함)

## 배경
HMS 메타데이터 변경 이벤트를 NOTIFICATION_LOG 에 적재(DataHub 등 메타데이터 감사/카탈로그 연동)하려면 `metastore.transactional.event.listeners=org.apache.hive.hcatalog.listener.DbNotificationListener` 설정이 필요. 이 클래스가 든 hcatalog-server-extensions jar 가 standalone-metastore 에 없어 이미지에 추가.

기존 CI(`.github/workflows/hive-metastore.yml`, native paths 기반)가 그대로 빌드/푸시. merge 시 `3.1.3-hadoop3.3.4-{date}` + `latest` 태그로 푸시됨.

## 검증 완료
- 로컬 빌드 이미지에서 `org/apache/hive/hcatalog/listener/DbNotificationListener.class` 포함 확인

## Test plan
- [ ] PR CI build 성공 (push=false)
- [ ] merge 후 main CI 에서 Docker Hub 푸시 성공
- [ ] 푸시된 태그로 dev HMS 배포 → pod 정상 기동(ClassNotFound 없음) + NOTIFICATION_LOG 적재 확인