### PR TITLE
chore: redact AWS account id in debezium-connect README

### DIFF
--- a/containers/debezium-connect/README.md
+++ b/containers/debezium-connect/README.md
@@ -7,7 +7,7 @@
 * [confluent maven](https://packages.confluent.io/maven/)
 
 ```shell
-aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin 101047223697.dkr.ecr.ap-northeast-2.amazonaws.com
+aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin <AWS_ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com
 ```
 
 ```bash
@@ -23,7 +23,7 @@ docker build \
   --build-arg KAFKA_VERSION=${KAFKA_VERSION} \
   -t shepherd9664/debezium-connect:${TAG} \
   ./
-docker tag shepherd9664/debezium-connect:${TAG} 101047223697.dkr.ecr.ap-northeast-2.amazonaws.com/de/debezium:${TAG}
+docker tag shepherd9664/debezium-connect:${TAG} <AWS_ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/de/debezium:${TAG}
 ```
 
 ## push
@@ -41,12 +41,12 @@ docker build \
   --build-arg KAFKA_VERSION=${KAFKA_VERSION} \
   -t shepherd9664/debezium-connect:${TAG} \
   ./
-docker tag shepherd9664/debezium-connect:${TAG} 101047223697.dkr.ecr.ap-northeast-2.amazonaws.com/de/debezium:${TAG}
+docker tag shepherd9664/debezium-connect:${TAG} <AWS_ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/de/debezium:${TAG}
 ```
 
 ```shell
-docker tag shepherd9664/debezium-connect:${TAG} 101047223697.dkr.ecr.ap-northeast-2.amazonaws.com/de/debezium:${TAG}
-docker push 101047223697.dkr.ecr.ap-northeast-2.amazonaws.com/de/debezium:${TAG}
+docker tag shepherd9664/debezium-connect:${TAG} <AWS_ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/de/debezium:${TAG}
+docker push <AWS_ACCOUNT_ID>.dkr.ecr.ap-northeast-2.amazonaws.com/de/debezium:${TAG}
 docker push shepherd9664/debezium-connect:${TAG}
 echo shepherd9664/debezium-connect:${TAG}
 ```


### PR DESCRIPTION
## Summary
- public repo의 `containers/debezium-connect/README.md` ECR 예시에서 AWS account id(`101047223697`)를 `<AWS_ACCOUNT_ID>` placeholder로 치환 (5곳)
- 시크릿은 아니지만 사내 계정 정보 노출 최소화. README 문서 변경만, 빌드 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)